### PR TITLE
Pause and stop controller in dispose method

### DIFF
--- a/lib/src/kinescope_player_controller.dart
+++ b/lib/src/kinescope_player_controller.dart
@@ -113,7 +113,7 @@ class KinescopePlayerController {
 
   /// Close [statusController] and [timeUpdateController] stream.
   void dispose() {
-    controllerProxy..pause()..stop();
+    controllerProxy.pause();
     statusController.close();
     timeUpdateController.close();
   }

--- a/lib/src/kinescope_player_controller.dart
+++ b/lib/src/kinescope_player_controller.dart
@@ -113,6 +113,7 @@ class KinescopePlayerController {
 
   /// Close [statusController] and [timeUpdateController] stream.
   void dispose() {
+    controllerProxy..pause()..stop();
     statusController.close();
     timeUpdateController.close();
   }


### PR DESCRIPTION
In iOS, after leaving the Kinescope video player screen, the video does not stop. So have to pause and stop controller in dispose method

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a pause call in `KinescopePlayerController.dispose()` to stop playback before closing streams.
> 
> - **Controller lifecycle**:
>   - Add `controllerProxy.pause()` in `KinescopePlayerController.dispose()` to halt playback before closing `statusController` and `timeUpdateController`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14efd28a02bc097c00de7409fbcee9187dbc3369. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->